### PR TITLE
Fix UnicodeDecodeError during installation on Windows: explicitly read README.md with UTF‑8 encoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     },
 
     description="python sdk for membase operation: memory, knowledge, chain, auth etc.",
-    long_description=open("README.md").read(),
+    long_description=open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     author="",
     author_email="",


### PR DESCRIPTION
On Windows systems (e.g. CPython 3.11), `pip install membase` fails with:

```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 1423: character maps to <undefined>
```

This is caused by the default `open("README.md")` using the system encoding (cp1252 on Windows), which breaks when encountering non-ASCII characters.

---

**Fix:**
Change:

```python
long_description = open("README.md").read()
```

to:

```python
long_description = open("README.md", encoding="utf‑8").read()
```

---

**Impact/Rationale:**

* Ensures consistent behavior across different platforms and locales
* Prevents read errors during installation
* Aligns with best practices for packaging: explicitly specifying UTF‑8 for text files ([docs.lucee.org][1], [pyopensci.org][2], [stackoverflow.com][3], [til.simonwillison.net][4])

---

**Verification:**
Successfully tested `pip install -e .` and packaging on Windows with Python 3.11 without errors.

---

**Checklist:**

* [x] Added `encoding="utf‑8"` to README.md file open call
* [x] Verified successful installation on Windows & Linux
* [ ] All existing tests pass (if applicable)
