### PR TITLE
storage: send Authorization on all hub API calls

### DIFF
--- a/src/membase/storage/_auth.py
+++ b/src/membase/storage/_auth.py
@@ -1,0 +1,148 @@
+"""
+Authorization header builder for the membase Hub API.
+
+Matches the Go SDK scheme in github.com/unibaseio/da-sdk-go:
+
+    digest = sha256(hash_label || uint64_be(unix_seconds))
+    sign   = ECDSA over secp256k1 -> 65 bytes (r || s || v, v in {0,1})
+    payload = {
+        "Type":"",
+        "Addr":"0x...",
+        "Time":<int>,
+        "Hash":"0x<hex>",
+        "Sign":"0x<hex>",
+    }
+    header_value = compact JSON of payload (no spaces)
+
+The hub side (``sdk.DecodeAuth`` in da-sdk-go) accepts this plain-JSON form
+via its fallback branch when the header value is not pure hex.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import struct
+import time as _time
+from typing import Dict, Optional
+
+from eth_keys import keys
+
+
+def _privkey_bytes(privkey: str) -> bytes:
+    if privkey.startswith("0x") or privkey.startswith("0X"):
+        privkey = privkey[2:]
+    pb = bytes.fromhex(privkey)
+    if len(pb) != 32:
+        raise ValueError(f"private key must be 32 bytes, got {len(pb)}")
+    return pb
+
+
+def _normalize_addr(addr: str) -> str:
+    a = addr.strip()
+    if not a:
+        raise ValueError("wallet address is empty")
+    if not a.startswith("0x"):
+        a = "0x" + a
+    if len(a) != 42:
+        raise ValueError(f"wallet address must be 20 hex bytes (got {len(a)})")
+    return a
+
+
+def _resolve_credentials(
+    private_key: Optional[str],
+    wallet_address: Optional[str],
+) -> tuple[str, str]:
+    pk = private_key or os.getenv("MEMBASE_SECRET_KEY", "")
+    addr = wallet_address or os.getenv("MEMBASE_ACCOUNT", "")
+    if not pk:
+        raise RuntimeError(
+            "MEMBASE_SECRET_KEY is not set; cannot authenticate against the membase hub"
+        )
+    if not addr:
+        raise RuntimeError(
+            "MEMBASE_ACCOUNT is not set; cannot authenticate against the membase hub"
+        )
+    return pk, _normalize_addr(addr)
+
+
+def build_authorization(
+    *,
+    hash_label: bytes = b"hub",
+    private_key: Optional[str] = None,
+    wallet_address: Optional[str] = None,
+    now: Optional[int] = None,
+) -> str:
+    """Build a single Authorization header *value* the Go hub will accept.
+
+    Args:
+        hash_label: arbitrary purpose label (must be non-empty bytes). The Go
+            SDK uses labels like b"hub", b"upload", b"register". The hub does
+            not verify the label content; only that the recovered address
+            matches ``Addr``.
+        private_key: hex secret (with or without ``0x``), 32 raw bytes. If
+            omitted, read from env ``MEMBASE_SECRET_KEY``.
+        wallet_address: 0x-prefixed ETH address. If omitted, read from env
+            ``MEMBASE_ACCOUNT``. Must correspond to ``private_key``.
+        now: unix seconds override (test only).
+
+    Returns:
+        Compact JSON string suitable as an Authorization header value.
+
+    Raises:
+        RuntimeError: if credentials are missing.
+        ValueError: if credentials are malformed.
+    """
+    if not hash_label:
+        raise ValueError("hash_label must be non-empty")
+
+    pk_hex, addr = _resolve_credentials(private_key, wallet_address)
+
+    ts = int(_time.time()) if now is None else int(now)
+
+    h = hashlib.sha256()
+    h.update(hash_label)
+    h.update(struct.pack(">Q", ts))
+    digest = h.digest()
+
+    pk = keys.PrivateKey(_privkey_bytes(pk_hex))
+    sig = pk.sign_msg_hash(digest)
+    sig_bytes = sig.to_bytes()  # 65 bytes r||s||v, v in {0,1}
+    if len(sig_bytes) != 65:
+        raise RuntimeError(f"unexpected signature length {len(sig_bytes)}")
+
+    payload = {
+        "Type": "",
+        "Addr": addr,
+        "Time": ts,
+        "Hash": "0x" + hash_label.hex(),
+        "Sign": "0x" + sig_bytes.hex(),
+    }
+    return json.dumps(payload, separators=(",", ":"))
+
+
+def auth_headers(
+    hash_label: bytes = b"hub",
+    *,
+    extra: Optional[Dict[str, str]] = None,
+    private_key: Optional[str] = None,
+    wallet_address: Optional[str] = None,
+) -> Dict[str, str]:
+    """Convenience: return a headers dict containing Authorization (+ extras)."""
+    h: Dict[str, str] = {
+        "Authorization": build_authorization(
+            hash_label=hash_label,
+            private_key=private_key,
+            wallet_address=wallet_address,
+        )
+    }
+    if extra:
+        h.update(extra)
+    return h
+
+
+def signer_address(wallet_address: Optional[str] = None) -> str:
+    """Return the lowercase 0x-prefixed wallet address this client signs with."""
+    _, addr = _resolve_credentials(None, wallet_address)
+    return addr.lower()

--- a/src/membase/storage/hub.py
+++ b/src/membase/storage/hub.py
@@ -9,7 +9,31 @@ import threading
 import time
 
 import logging
+
+from membase.storage._auth import auth_headers, signer_address
+
 logger = logging.getLogger(__name__)
+
+
+def _coerce_owner(owner: Optional[str]) -> str:
+    """Make sure the owner field sent to the hub is the signer's ETH address.
+
+    The hub now requires ``owner == recovered signer address``. Callers used
+    to pass arbitrary strings like ``"noah-2026"``; those will 401. We force
+    the owner to the configured wallet and warn loudly if the caller passed
+    something else, so we don't silently swallow surprising input.
+    """
+    signer = signer_address()
+    if owner and owner.lower() != signer.lower():
+        logger.warning(
+            "membase hub: overriding owner=%r with signer wallet %s "
+            "(hub requires owner == signer; the legacy 'arbitrary owner' "
+            "behaviour is no longer accepted)",
+            owner,
+            signer,
+        )
+    return signer
+
 
 class Client:
     def __init__(self, base_url):
@@ -25,8 +49,9 @@ class Client:
                 upload_task = self.upload_queue.get()
                 if upload_task is None:
                     break
-                
+
                 owner, bucket, filename, msg, event = upload_task
+                owner = _coerce_owner(owner)
                 meme_struct = {
                     "owner": owner,
                     "bucket": bucket,
@@ -35,16 +60,19 @@ class Client:
                 }
 
                 meme_struct_json = json.dumps(meme_struct)
-                headers = {'Content-Type': 'application/json'}
-                
+                headers = auth_headers(
+                    b"upload",
+                    extra={"Content-Type": "application/json"},
+                )
+
                 response = requests.post(f"{self.base_url}/api/upload", headers=headers, data=meme_struct_json)
                 response.raise_for_status()
-                
+
                 res = response.json()
                 logger.debug(f"Upload done: {res}")
-                
+
                 event.set()
-                
+
             except requests.RequestException as err:
                 logger.error(f"Error during upload: {err}")
             except Exception as e:
@@ -59,22 +87,25 @@ class Client:
 
     def upload_hub(self, owner, filename, msg, bucket: Optional[str] = None, wait=True):
         """Add upload task to queue, optionally wait for completion
-        
+
         Args:
-            owner: Owner of the meme
+            owner: Owner of the meme. NOTE: the hub now requires this to be
+                the signer's wallet address; any other value is overridden
+                (with a warning) by the address derived from MEMBASE_ACCOUNT.
             filename: Name of the file
             msg: Message content
             bucket: Bucket name
             wait: Whether to wait for upload completion
-            
+
         Returns:
             If wait=True, returns upload result; if wait=False, returns queue status
         """
         try:
+            owner = _coerce_owner(owner)
             default_bucket = owner
             if self.membase_id != "":
                 default_bucket = self.membase_id
-                
+
             if bucket is None:
                 if isinstance(msg, str):
                     try:
@@ -82,7 +113,7 @@ class Client:
                         bucket = msg_dict.get("name", default_bucket)
                     except json.JSONDecodeError:
                         bucket = default_bucket
-                else:    
+                else:
                     bucket = default_bucket
 
             # Create an event object for synchronization
@@ -90,14 +121,14 @@ class Client:
             # Add upload task and event object to queue
             self.upload_queue.put((owner, bucket, filename, msg, event))
             logger.debug(f"Upload task queued: {owner}/{filename}")
-            
+
             if wait:
                 # Wait for upload completion
                 event.wait()
                 return {"status": "completed", "message": "Upload task completed"}
             else:
                 return {"status": "queued", "message": "Upload task has been queued"}
-                
+
         except Exception as e:
             logger.error(f"Error queueing upload task: {e}")
             return None
@@ -105,9 +136,11 @@ class Client:
     def upload_hub_data(self, owner, filename, data):
         """Upload meme data to the hub server with multipart form."""
         try:
+            owner = _coerce_owner(owner)
+
             # Create a BytesIO stream from the data to simulate a file-like object
             file_stream = BytesIO(data)
-            
+
             # Prepare the files and data for the multipart request
             files = {
                 'file': (filename, file_stream, 'application/octet-stream')
@@ -116,8 +149,17 @@ class Client:
                 'owner': owner
             }
 
+            # multipart Content-Type is set by requests automatically; we only
+            # need to inject Authorization.
+            headers = auth_headers(b"upload")
+
             # Send the POST request to upload data
-            response = requests.post(f"{self.base_url}/api/uploadData", files=files, data=data)
+            response = requests.post(
+                f"{self.base_url}/api/uploadData",
+                files=files,
+                data=data,
+                headers=headers,
+            )
 
             # Raise an exception if the request was not successful
             response.raise_for_status()
@@ -137,35 +179,51 @@ class Client:
 
     def list_conversations(self, owner):
         """List all conversations for a given owner."""
+        owner = _coerce_owner(owner)
         # Prepare the form data (URL-encoded parameters)
         form_data = {
             'owner': owner,
         }
-            
+
         # URL encode the form data
         encoded_form = urlencode(form_data)
-        
-        try:    
-            response = requests.post(f"{self.base_url}/api/conversation", data=encoded_form, headers={'Content-Type': 'application/x-www-form-urlencoded'})
+
+        try:
+            response = requests.post(
+                f"{self.base_url}/api/conversation",
+                data=encoded_form,
+                headers=auth_headers(
+                    b"list",
+                    extra={"Content-Type": "application/x-www-form-urlencoded"},
+                ),
+            )
             response.raise_for_status()
             return response.json()
         except requests.RequestException as err:
             logger.error(f"Error during list conversations: {err}")
             return None
-    
+
     def get_conversation(self, owner, conversation_id):
         """Get a conversation for a given owner and conversation id."""
+        owner = _coerce_owner(owner)
         # Prepare the form data (URL-encoded parameters)
         form_data = {
             'owner': owner,
             'id': conversation_id,
         }
-            
+
         # URL encode the form data
         encoded_form = urlencode(form_data)
-        
-        try:    
-            response = requests.post(f"{self.base_url}/api/conversation", data=encoded_form, headers={'Content-Type': 'application/x-www-form-urlencoded'})
+
+        try:
+            response = requests.post(
+                f"{self.base_url}/api/conversation",
+                data=encoded_form,
+                headers=auth_headers(
+                    b"list",
+                    extra={"Content-Type": "application/x-www-form-urlencoded"},
+                ),
+            )
             response.raise_for_status()
             return response.json()
         except requests.RequestException as err:
@@ -175,27 +233,35 @@ class Client:
     def download_hub(self, owner, filename):
         """Download meme data from the hub server."""
         try:
+            owner = _coerce_owner(owner)
             # Prepare the form data (URL-encoded parameters)
             form_data = {
                 'id': filename,
                 'owner': owner,
             }
-            
+
             # URL encode the form data
             encoded_form = urlencode(form_data)
-            
+
             # Log the download action
             logger.debug(f"Downloading {owner} {filename} from hub {self.base_url}")
-            
+
             # Send the POST request with the encoded form data
-            response = requests.post(f"{self.base_url}/api/download", data=encoded_form, headers={'Content-Type': 'application/x-www-form-urlencoded'})
-            
+            response = requests.post(
+                f"{self.base_url}/api/download",
+                data=encoded_form,
+                headers=auth_headers(
+                    b"download",
+                    extra={"Content-Type": "application/x-www-form-urlencoded"},
+                ),
+            )
+
             # Raise an exception if the request was not successful
             response.raise_for_status()
-            
+
             # Return the response content (bytes)
             return response.content
-        
+
         except requests.RequestException as err:
             logger.error(f"Error during download: {err}")
             return None
@@ -204,5 +270,5 @@ class Client:
         """Wait for all tasks in the upload queue to complete"""
         self.upload_queue.join()
 
-he = os.getenv('MEMBASE_HUB', 'https://testnet.hub.membase.io')      
+he = os.getenv('MEMBASE_HUB', 'https://testnet.hub.membase.io')
 hub_client = Client(he)


### PR DESCRIPTION
The /api/upload, /api/uploadData, /api/download and /api/conversation endpoints on the Go hub now require a valid Authorization header (see unibaseio/da-sdk-go hub: require Authorization on /api). Without this change, every membase hub call from Python would 401.

  - src/membase/storage/_auth.py (new): build_authorization() and auth_headers() helpers that reproduce the Go SDK signing scheme: digest = sha256(hash_label || be_uint64(unix_seconds))
        sig    = secp256k1 raw sign -> 65 B (r||s||v, v in {0,1})
    Output is compact JSON consumed by sdk.DecodeAuth's plain-JSON
    fallback branch. Credentials come from MEMBASE_SECRET_KEY and
    MEMBASE_ACCOUNT env vars - no new config.

  - src/membase/storage/hub.py: every requests.post call now passes auth_headers(...) with an appropriate purpose label ("upload", "download", "list"). A new _coerce_owner() helper forces the `owner` field to the signer's wallet address and warns when a caller passes a different value, so legacy code passing arbitrary owner strings ("noah-2026" etc.) keeps working but lands in the correct namespace instead of 401-ing.

Verified by round-tripping a Python-built header through sdk.DecodeAuth + sdk.VerifyAuth in the da-sdk-go repo: VERIFY OK. No new package deps - eth_keys is already a transitive dep of web3.